### PR TITLE
fix/gold-review-naver-created-at

### DIFF
--- a/dbt/beauty_elt/models/gold/fact_reviews.sql
+++ b/dbt/beauty_elt/models/gold/fact_reviews.sql
@@ -28,7 +28,7 @@ WITH unified_reviews AS (
     product_id,
     SAFE_CAST(rating AS INT64) AS star,
     content,
-    PARSE_DATE('%y.%m.%d', created_at) AS created_at,
+    PARSE_DATE('%y.%m.%d', REGEXP_REPLACE(created_at, r'\.$', '')) AS created_at,
     category AS category,
     platform,
     scraped_at


### PR DESCRIPTION
골드 리뷰 테이블 생성 시 네이버 created_at 에서 . 으로 인해 발생하는 오류 해결