### PR TITLE
feat/gold-products-schedule-change

### DIFF
--- a/dags/gold-layer/gold_products.py
+++ b/dags/gold-layer/gold_products.py
@@ -10,7 +10,7 @@ default_args = {
 with DAG(
     dag_id="gold_products_dbt_run",
     start_date=days_ago(1),
-    schedule_interval="0 15 * * *", # 매일 오후 3시 UTC → 한국 시간 기준 자정
+    schedule_interval = "30 3 * * *", # 매일 오전 3시 30분 UTC → 한국 시간 기준 정오 12시 30분 
     catchup=False,
     tags=["gold", "dbt", "product"]
 ) as dag:


### PR DESCRIPTION
골드 계층 상품 테이블 스케쥴을 utc 기준 오후 3시에서 오전 3시 30분으로 수정
- 코드를 확인한 결과 상품의 경우 브론즈 및 실버 스케쥴이 오전 3시로 되어 있고, 리뷰의 경우 브론즈 및 실버 스케쥴이 오후 2시 30분으로 되어 있는 것으로 확인
- 실버 계층까지 적재가 완료된 것을 확인하고 30분 정도의 시간 차를 두고 실행하는 것으로 계획
- 리뷰 테이블의 경우 오후 3시 utc 기반 유지, 상품 테이블만 오전 3시 30분으로 수정